### PR TITLE
Implement prop scrollRenderAheadDistance

### DIFF
--- a/lib/YYListView.js
+++ b/lib/YYListView.js
@@ -48,10 +48,12 @@ class YYListView extends Component {
    */
   onScroll(e) {
         // Calculate the current content offsets
-    const contentOffsetX = e.nativeEvent.contentOffset.x - this.props.scrollRenderAheadDistance;
-    const contentOffsetY = e.nativeEvent.contentOffset.y - this.props.scrollRenderAheadDistance;
-    const layoutMeasurementWidth = e.nativeEvent.layoutMeasurement.width + this.props.scrollRenderAheadDistance;
-    const layoutMeasurementHeight = e.nativeEvent.layoutMeasurement.height + this.props.scrollRenderAheadDistance;
+    const { scrollRenderAheadDistance } = this.props;
+    const { contentOffset, layoutMeasurement } = e.nativeEvent;
+    const contentOffsetX = contentOffset.x - scrollRenderAheadDistance;
+    const contentOffsetY = contentOffset.y - scrollRenderAheadDistance;
+    const layoutMeasurementWidth = layoutMeasurement.width + scrollRenderAheadDistance;
+    const layoutMeasurementHeight = layoutMeasurement.height + scrollRenderAheadDistance;
     const currentOffset = [
       this.props.horizontal ? contentOffsetX : contentOffsetY,
       this.props.horizontal ? (contentOffsetX + layoutMeasurementWidth)

--- a/lib/YYListView.js
+++ b/lib/YYListView.js
@@ -7,6 +7,12 @@ const isIOS = Platform.OS === 'ios';
 const propTypes = {
   ...ListView.propTypes,
   renderScrollComponent: PropTypes.func,
+  scrollRenderAheadDistance: PropTypes.number,
+};
+
+const defaultProps = {
+  ...ListView.defaultProps,
+  scrollRenderAheadDistance: 0,
 };
 
 class YYListView extends Component {
@@ -42,10 +48,10 @@ class YYListView extends Component {
    */
   onScroll(e) {
         // Calculate the current content offsets
-    const contentOffsetX = e.nativeEvent.contentOffset.x;
-    const contentOffsetY = e.nativeEvent.contentOffset.y;
-    const layoutMeasurementWidth = e.nativeEvent.layoutMeasurement.width;
-    const layoutMeasurementHeight = e.nativeEvent.layoutMeasurement.height;
+    const contentOffsetX = e.nativeEvent.contentOffset.x - this.props.scrollRenderAheadDistance;
+    const contentOffsetY = e.nativeEvent.contentOffset.y - this.props.scrollRenderAheadDistance;
+    const layoutMeasurementWidth = e.nativeEvent.layoutMeasurement.width + this.props.scrollRenderAheadDistance;
+    const layoutMeasurementHeight = e.nativeEvent.layoutMeasurement.height + this.props.scrollRenderAheadDistance;
     const currentOffset = [
       this.props.horizontal ? contentOffsetX : contentOffsetY,
       this.props.horizontal ? (contentOffsetX + layoutMeasurementWidth)
@@ -197,5 +203,6 @@ class YYListView extends Component {
   }
 }
 
-YYListView.defaultPropTypes = propTypes;
+YYListView.propTypes = propTypes;
+YYListView.defaultProps = defaultProps;
 export default YYListView;


### PR DESCRIPTION
Sometimes you want to pre-render content that is off the screen. This PR just increases the `currentOffset` with the prop `scrollRenderAheadDistance`. See https://facebook.github.io/react-native/docs/listview.html#scrollrenderaheaddistance.